### PR TITLE
exclude `/exporter/group/octane-metrics` route from being tracked

### DIFF
--- a/src/Listeners/TrackTerminatedRequests.php
+++ b/src/Listeners/TrackTerminatedRequests.php
@@ -15,6 +15,10 @@ class TrackTerminatedRequests
      */
     public function handle(RequestTerminated $event): void
     {
+        if (request()->route()->getName() === 'laravel-exporter.metrics') {
+            return;
+        }
+
         $this->incrementRequestsCount();
 
         $statusCode = $event->response->getStatusCode();


### PR DESCRIPTION
This PR aims to exclude `/exporter/group/octane-metrics` route from being tracked to have more accurate request counts from exporter.